### PR TITLE
fix: race condition in getting current plugin

### DIFF
--- a/src/hooks/useGetCurrentPlugin.tsx
+++ b/src/hooks/useGetCurrentPlugin.tsx
@@ -2,17 +2,20 @@ import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { getPlugin } from '@pluginRegistry'
 import { selectSourceChain } from '@store/selectors'
+import { selectPluginIsIndexed } from '@store/pluginSlice'
 import defaultPlugin from '@plugins/default'
 import { Plugin } from '@plugins/pluginTypes'
 
 const useGetCurrentPlugin = () => {
   const [currentPlugin, setCurrentPlugin] = useState<Plugin>(defaultPlugin)
+  const isIndexed = useSelector(selectPluginIsIndexed)
   const sourceChainID = useSelector(selectSourceChain)
 
   useEffect(() => {
+    if (!isIndexed) return
     const plugin = getPlugin(sourceChainID)
     if (plugin) setCurrentPlugin(plugin)
-  }, [sourceChainID])
+  }, [sourceChainID, isIndexed])
 
   return { currentPlugin }
 }

--- a/src/pluginRegistry.ts
+++ b/src/pluginRegistry.ts
@@ -1,5 +1,5 @@
 import store from './store'
-import { registerPlugin } from '@store/pluginSlice'
+import { registerPlugin, setPluginIsIndexed } from '@store/pluginSlice'
 import { ChainData, Plugin } from '@plugins/pluginTypes'
 
 // Registry to hold plugin provider components
@@ -38,9 +38,15 @@ export const indexPluginsByChain = (chains: ChainData[]): void => {
     pluginsByChain[chain.shortName] = plugin
   }
   console.log('pluginsByChain::', pluginsByChain)
+
+  // Update the store to indicate that the chain to plugin mapping has been indexed
+  // Prevents a race condition where the useGetCurrentPlugin hook may be called
+  // before the plugins are indexed by chain
+  store.dispatch(setPluginIsIndexed(true))
 }
 
 export const getPlugin = (chain: string): Plugin | undefined => {
+  console.log('getPlugin::', { chain, pluginsByChain })
   if (!chain) return undefined
   return pluginsByChain[chain]
 }

--- a/src/store/pluginSlice.tsx
+++ b/src/store/pluginSlice.tsx
@@ -9,11 +9,13 @@ export interface Plugin {
 
 // Define the shape of the slice state
 export interface PluginState {
+  isIndexed: boolean // Flag to indicate if the chain to plugin mapping has been indexed
   plugins: Record<string, Plugin> // Stores plugin metadata and data
 }
 
 // Initial state
 const initialState: PluginState = {
+  isIndexed: false,
   plugins: {} // Empty record of plugins
 }
 
@@ -32,6 +34,11 @@ const pluginSlice = createSlice({
     ) => {
       const { id, pluginData } = action.payload
       state.plugins[id] = { id, pluginData }
+    },
+
+    // update index flag
+    setPluginIsIndexed: (state, action: PayloadAction<boolean>) => {
+      state.isIndexed = action.payload
     },
 
     // Action to update plugin data (e.g., networks or other dynamic values)
@@ -54,13 +61,17 @@ const pluginSlice = createSlice({
 })
 
 // Actions
-export const { registerPlugin, updatePluginData } = pluginSlice.actions
+export const { registerPlugin, setPluginIsIndexed, updatePluginData } =
+  pluginSlice.actions
 
 // Selectors
 export const selectPlugin = (
   state: RootState,
   id: string
 ): Plugin | undefined => state.plugins.plugins[id]
+
+export const selectPluginIsIndexed = (state: RootState): boolean =>
+  state.plugins.isIndexed
 
 export const selectAllPlugins = (state: RootState): Plugin[] =>
   Object.values(state.plugins.plugins)


### PR DESCRIPTION
Fixes a race condition on initial page load where the `useCurrentPlugin` hook would attempt to fetch the current plugin before the mapping of chain to plugin is complete.
* Adds a new `isIndexed` flag to the plugin state slice
* The `useCurrentPlugin` hook uses the new flag to get the current plugin only after the mapping has been indexed