### PR TITLE
fix: max amount value

### DIFF
--- a/src/components/reusable/SingleForm.tsx
+++ b/src/components/reusable/SingleForm.tsx
@@ -88,10 +88,7 @@ const SingleForm = ({
   )
 
   const maxValue = useMemo(() => {
-    // console.log('maxValue:balance: ', balance)
-    // console.log('maxalue:service fee: ', totalFeeUsd)
-    if (!balance || !totalFeeUsd) return 0
-
+    if (!balance) return 0
     if (feeDeduct || totalFeeUsd < 0) return balance
 
     const amountMinusFees = preciseSubtraction(balance as number, totalFeeUsd)

--- a/src/hooks/useValidateTransaction.tsx
+++ b/src/hooks/useValidateTransaction.tsx
@@ -44,18 +44,16 @@ const useValidateTransaction = ({
   pools: any[]
 }) => {
   const maxValue = useMemo(() => {
-    // console.log('maxValue:balance: ', balance)
-    // console.log('maxalue:service fee: ', totalFeeUsd)
-    if (!balance || !totalFeeUsd) return 0
+    if (!balance) return 0
 
     if (feeDeduct || totalFeeUsd < 0) return balance
 
     const amountMinusFees = preciseSubtraction(balance as number, totalFeeUsd)
-    console.log("amountMinusFees: ", amountMinusFees)
-    return amountMinusFees > 0 ? amountMinusFees : 0
-  }, [balance, totalFeeUsd, feeDeduct])
+    const maxVal = amountMinusFees > 0 ? amountMinusFees : 0
+    console.log('maxValue: ', { maxVal, amountMinusFees })
 
-  console.log("maxValue: ", maxValue)
+    return maxVal
+  }, [balance, totalFeeUsd, feeDeduct])
 
   const validate = (isSubmitting: boolean = false) => {
     console.log('allowance: ', allowance)


### PR DESCRIPTION
Fixes a bug where the max amount in the input was zero on Solana even when the USDK balance as not zero
* The `useMemo` was returning zero when `totalFeeUsd` was not defined, but the fee is not fetched until there is an amount, resulting in a case where it would always return zero
