### PR TITLE
fix: add back dappOptions and keplrHandler, switchChainHandler

### DIFF
--- a/src/components/KimaTransactionWidget.tsx
+++ b/src/components/KimaTransactionWidget.tsx
@@ -7,7 +7,8 @@ import {
   TitleOption,
   PaymentTitleOption,
   ColorModeOptions,
-  NetworkOptions
+  NetworkOptions,
+  DAppOptions
 } from '../interface'
 
 // store
@@ -32,7 +33,8 @@ import {
   setExcludedSourceNetworks,
   setExcludedTargetNetworks,
   setTargetCurrency,
-  setSourceChain
+  setSourceChain,
+  setDappOption
 } from '../store/optionSlice'
 import '../index.css'
 import { selectSubmitted } from '../store/selectors'
@@ -47,7 +49,7 @@ interface Props {
   theme: ThemeOptions
   mode: ModeOptions
   txId?: number
-  autoSwitchChain?: boolean
+  dAppOption?: DAppOptions
   titleOption?: TitleOption
   compliantOption?: boolean
   helpURL?: string
@@ -68,8 +70,8 @@ interface Props {
 const KimaTransactionWidget = ({
   mode,
   txId,
-  autoSwitchChain = true,
   networkOption = NetworkOptions.testnet,
+  dAppOption = DAppOptions.None,
   theme,
   titleOption,
   paymentTitleOption,
@@ -114,6 +116,7 @@ const KimaTransactionWidget = ({
     dispatch(setSwitchChainHandler(switchChainHandler))
     dispatch(setBackendUrl(kimaBackendUrl))
     dispatch(setMode(mode))
+    dispatch(setDappOption(dAppOption))
     dispatch(setNetworkOption(networkOption))
 
     if (transactionOption) {

--- a/src/components/TransferWidget.tsx
+++ b/src/components/TransferWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useMemo } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ErrorIcon, FooterLogo } from '../assets/icons'
 import {
@@ -10,6 +10,7 @@ import {
 } from './reusable'
 import {
   ColorModeOptions,
+  DAppOptions,
   ModeOptions,
   PaymentTitleOption,
   ThemeOptions,
@@ -31,7 +32,9 @@ import {
   selectBackendUrl,
   selectCloseHandler,
   selectCompliantOption,
+  selectDappOption,
   selectFeeDeduct,
+  selectKeplrHandler,
   selectMode,
   selectNetworkOption,
   selectPendingTxs,
@@ -78,6 +81,8 @@ export const TransferWidget = ({
   const [formStep, setFormStep] = useState(0)
 
   // Redux variables
+  const dAppOption = useSelector(selectDappOption)
+  const keplrHandler = useSelector(selectKeplrHandler)
   const mode = useSelector(selectMode)
   const transactionOption = useSelector(selectTransactionOption)
   const backendUrl = useSelector(selectBackendUrl)
@@ -174,6 +179,17 @@ export const TransferWidget = ({
     // if is missing approve, trigger approval
     if (error === ValidationError.ApprovalNeeded) {
       return approve()
+    }
+
+    // for liquidity tranasctions, invoke the callback
+    // TODO: either fully support LP in the widget, or
+    // refactor to use a separate component
+    if (
+      dAppOption === DAppOptions.LPDrain ||
+      dAppOption === DAppOptions.LPAdd
+    ) {
+      keplrHandler && keplrHandler(sourceAddress)
+      return
     }
 
     // submit the kima transaction

--- a/src/components/primary/NetworkSelector.tsx
+++ b/src/components/primary/NetworkSelector.tsx
@@ -5,12 +5,14 @@ import {
   selectExcludedTargetNetworks,
   selectNetworks,
   selectSourceChain,
+  selectSwitchChainHandler,
   selectTargetChain,
   selectTheme
 } from '@store/selectors'
 import { setSourceChain, setTargetChain } from '@store/optionSlice'
 import Arrow from '@assets/icons/Arrow'
 import ChainIcon from '../reusable/ChainIcon'
+import { ChainName } from '@utils/constants'
 
 interface NetworkSelectorProps {
   type: 'source' | 'target' // Determines if this is a source or target selector
@@ -27,6 +29,7 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({ type }) => {
   const targetNetwork = useSelector(selectTargetChain)
   const excludedSourceNetworks = useSelector(selectExcludedSourceNetworks)
   const excludedTargetNetworks = useSelector(selectExcludedTargetNetworks)
+  const switchChainHandler = useSelector(selectSwitchChainHandler)
 
   const isSourceSelector = type === 'source'
 
@@ -34,15 +37,21 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({ type }) => {
   const networks = useMemo(() => {
     if (isSourceSelector) {
       return networkOptions.filter(
-        (network) => !excludedSourceNetworks.includes(network.id)
+        (network) => !excludedSourceNetworks.includes(network.id as ChainName)
       )
     }
     return networkOptions.filter(
       (network) =>
         network.id !== sourceNetwork &&
-        !excludedTargetNetworks.includes(network.id)
+        !excludedTargetNetworks.includes(network.id as ChainName)
     ) // Exclude source from target options
-  }, [networkOptions, sourceNetwork, isSourceSelector, excludedSourceNetworks, excludedTargetNetworks])
+  }, [
+    networkOptions,
+    sourceNetwork,
+    isSourceSelector,
+    excludedSourceNetworks,
+    excludedTargetNetworks
+  ])
 
   const selectedNetwork = useMemo(() => {
     const selectedId = isSourceSelector ? sourceNetwork : targetNetwork
@@ -72,6 +81,7 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({ type }) => {
     if (isSourceSelector) {
       if (networkId !== sourceNetwork) {
         dispatch(setSourceChain(networkId))
+        switchChainHandler && switchChainHandler(networkId)
       }
     } else {
       if (networkId !== targetNetwork) {


### PR DESCRIPTION
Fixes:
* Add back the `dappOption` prop as this is used for liquidity provision on the Explorer
* Add back the the LP logic when submitting a transaction that calls the `keplrHandler` callback
* Call the `switchChainHandler` callback when the source chain is switched

Chore
* Removed unused `autoSwitchChain` widget prop