### PR TITLE
fix: validation > pool target token not found

### DIFF
--- a/src/utils/functions.tsx
+++ b/src/utils/functions.tsx
@@ -57,6 +57,13 @@ export const checkPoolBalance = ({
   const targetToken = poolTokens.find(
     (token: any) => token.tokenSymbol === finalTargetCurrency
   )
+  
+  if (!targetToken) {
+    return {
+      isPoolAvailable: false,
+      error: `${CHAIN_NAMES_TO_STRING[targetChain]} has no ${targetCurrency} pool!`
+    }
+  }
   const { amount: targetTokenBalance } = targetToken
 
   // check if pool has enough balance


### PR DESCRIPTION
Validation
- Fixes: If the the target token does not exist in the pool balances list

This error came up for a client. It shouldn't happen, but it did. Must be a mismatch between the list of chains returned between different endpoints. This addition is good defensive programming anyway.