### PR TITLE
chore: remove include creds from POST /submit request

### DIFF
--- a/src/helpers/fetch-wrapper.tsx
+++ b/src/helpers/fetch-wrapper.tsx
@@ -18,10 +18,8 @@ function get(url: string) {
 function post(url: string, body: any) {
   const requestOptions: any = {
     method: 'POST',
-    credentials: 'include',
     headers: {
       'Content-Type': 'application/json'
-      // Authorization: `Bearer ${token}`
     },
     body: body
   }


### PR DESCRIPTION
Remove include credentials from `POST /submit` request.

⚠️ This is a breaking change. Will link the corresponding PR for the Backend that removes the CORS include credentials options.