### PR TITLE
fix: bigint from number rounding issue

### DIFF
--- a/src/helpers/functions.tsx
+++ b/src/helpers/functions.tsx
@@ -52,7 +52,9 @@ export const toBigintAmount = (
   data: BigintAmount<string>
 ): BigintAmount<bigint> => {
   return {
-    value: BigInt(data.value),
+    // bigint values constructed from numbers can have rounding errors!
+    // so need to convert to string and then to bigint
+    value: BigInt(data.value.toString()),
     decimals: data.decimals
   }
 }

--- a/src/hooks/useSubmitTransaction.tsx
+++ b/src/hooks/useSubmitTransaction.tsx
@@ -56,13 +56,14 @@ const useSubmitTransaction = () => {
         }),
         ccTransactionIdSeed: ccTransactionId
       })
+      log.debug('submitTransaction: params: ', params)
 
       let transactionResult: any = await fetchWrapper.post(
         `${backendUrl}/submit`,
         params
       )
 
-      console.log('transactionResult: ', transactionResult)
+      console.log('submitTransaction: response: ', transactionResult)
       if (transactionResult?.code !== 0) {
         setSubmitting(false)
         return { success: false, message: 'Failed to submit transaction' }

--- a/src/hooks/useSubmitTransaction.tsx
+++ b/src/hooks/useSubmitTransaction.tsx
@@ -63,7 +63,7 @@ const useSubmitTransaction = () => {
         params
       )
 
-      console.log('submitTransaction: response: ', transactionResult)
+      log.debug('submitTransaction: response: ', transactionResult)
       if (transactionResult?.code !== 0) {
         setSubmitting(false)
         return { success: false, message: 'Failed to submit transaction' }


### PR DESCRIPTION
Fixes a bug where constructing a `bigint` value from a JSON number results in rounding errors when converting back to string

![image](https://github.com/user-attachments/assets/776985e4-e3d4-428a-8f57-dee80b2435ac)


