### PR TITLE
feat(retry): retry handling on submit cc transaction

### DIFF
--- a/src/components/ErrorWidget.tsx
+++ b/src/components/ErrorWidget.tsx
@@ -1,7 +1,15 @@
-import { ErrorIcon, FooterLogo } from '@assets/icons'
-import { ColorModeOptions, ThemeOptions } from '@interface'
 import React from 'react'
-import { PrimaryButton } from './reusable'
+import { useSelector } from 'react-redux'
+
+import { ErrorIcon, FooterLogo } from '@assets/icons'
+import { CopyButton, PrimaryButton } from './reusable'
+import { ColorModeOptions, ThemeOptions } from '@interface'
+import {
+  selectCCTransactionId,
+  selectCCTransactionRetrying,
+  selectSourceChain
+} from '@store/selectors'
+import { Loading180Ring } from '@assets/loading'
 
 const ErrorWidget = ({
   theme,
@@ -14,8 +22,14 @@ const ErrorWidget = ({
   title: string
   message: string
   backButtonEnabled?: boolean
-  backButtonFunction?: any
+  backButtonFunction?: () => void
 }) => {
+  const sourceChain = useSelector(selectSourceChain)
+  const ccTransactionId = useSelector(selectCCTransactionId)
+
+  const isCreditCardSource = sourceChain.shortName === 'CC'
+  const isRetrying = useSelector(selectCCTransactionRetrying)
+
   return (
     <div
       className={`kima-card ${theme.colorMode}`}
@@ -33,24 +47,74 @@ const ErrorWidget = ({
               <h3>{title}</h3>
             </div>
           </div>
-
           <h4 className='subtitle'></h4>
         </div>
 
         <div className='kima-card-content error'>
           <ErrorIcon width={40} height={40} />
           <h2>{message}</h2>
+
+          {isCreditCardSource && (
+            <div style={{ marginTop: 16 }}>
+              {isRetrying ? (
+                <p>
+                  The transaction is being retried in the background. This may
+                  take a few moments. If the issue persists, please contact
+                  support and provide the transaction ID below for reference.
+                </p>
+              ) : (
+                <p>
+                  This credit card transaction has failed. Please check the
+                  details and try again. If the issue persists, please contact
+                  support and provide the transaction ID below for reference.
+                </p>
+              )}
+
+              {ccTransactionId && (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    marginTop: 8,
+                    justifyContent: 'center'
+                  }}
+                >
+                  <code
+                    style={{
+                      fontFamily: 'monospace',
+                      wordBreak: 'break-all',
+                      marginRight: 10
+                    }}
+                  >
+                    {ccTransactionId}
+                  </code>
+                  <CopyButton text={ccTransactionId} />
+                </div>
+              )}
+
+              {isRetrying && (
+                <Loading180Ring width={30} height={30} fill='#86b8ce' />
+              )}
+            </div>
+          )}
         </div>
 
         {backButtonEnabled && (
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              marginTop: 16
+            }}
+          >
             <PrimaryButton clickHandler={backButtonFunction}>
               Back
             </PrimaryButton>
           </div>
         )}
 
-        <div className={`kima-card-footer`}></div>
+        <div className='kima-card-footer'></div>
+
         <div className='floating-footer'>
           <div className={`items ${theme.colorMode}`}>
             <span>Powered by</span>

--- a/src/components/KimaTransactionWidget.tsx
+++ b/src/components/KimaTransactionWidget.tsx
@@ -31,7 +31,10 @@ import SkeletonLoader from 'src/SkeletonLoader'
 import ErrorWidget from './ErrorWidget'
 import { Loading180Ring } from '@assets/loading'
 import { useSelector } from 'react-redux'
-import { selectCCTransactionStatus } from '@store/selectors'
+import {
+  selectCCTransactionRetrying,
+  selectCCTransactionStatus
+} from '@store/selectors'
 
 interface Props {
   theme: ThemeOptions
@@ -65,6 +68,7 @@ const KimaTransactionWidget = ({
 
   const [hydrated, setHydrated] = useState(false)
   const ccTransactionStatus = useSelector(selectCCTransactionStatus)
+  const ccTransactionRetrying = useSelector(selectCCTransactionRetrying)
 
   const {
     data: envOptions,
@@ -97,7 +101,8 @@ const KimaTransactionWidget = ({
   }, [theme?.colorMode])
 
   // Don't render until hydrated and theme is defined
-  if (!hydrated || !theme?.colorMode) return <Loading180Ring width={20} height={20} fill='#86b8ce' />
+  if (!hydrated || !theme?.colorMode)
+    return <Loading180Ring width={20} height={20} fill='#86b8ce' />
 
   if (isLoadingEnvs || isLoadingChainData)
     return <SkeletonLoader theme={theme} />
@@ -111,18 +116,18 @@ const KimaTransactionWidget = ({
         backButtonEnabled={true}
         backButtonFunction={() => {
           dispatch(setAmount(''))
-          dispatch(setCCTransactionStatus('idle'));
+          dispatch(setCCTransactionStatus('idle'))
         }}
       />
     )
 
-    if (ccTransactionStatus === 'error-generic')
+  if (ccTransactionStatus === 'error-generic')
     return (
       <ErrorWidget
         theme={theme}
         title='Credit Card Transaction Error'
-        message="There was an error sending the transaction. Please verify that the amount, chains and target address are correct, if the error persists contact us."
-        backButtonEnabled={true}
+        message='There was an error sending the transaction. Please verify that the amount, chains and target address are correct.'
+        backButtonEnabled={!ccTransactionRetrying}
         backButtonFunction={() => {
           dispatch(setAmount(''))
           dispatch(setCCTransactionStatus('idle'))

--- a/src/store/optionSlice.tsx
+++ b/src/store/optionSlice.tsx
@@ -126,7 +126,14 @@ export interface OptionState {
   kimaExplorerUrl: string // URL for kima explore (testnet, staging or demo)
   txId?: number | string // transaction id to monitor it's status
   ccTransactionId: string // transaction id generated for submitting a credit card transaction
-  ccTransactionStatus: 'initialized' | 'success' | 'failed' | 'idle' | 'error-id' | 'error-generic' // credit card transaction status
+  ccTransactionStatus:
+    | 'initialized'
+    | 'success'
+    | 'failed'
+    | 'idle'
+    | 'error-id'
+    | 'error-generic' // credit card transaction status
+  ccTransactionRetrying: boolean // credit card tx retrying status
   sourceCurrency: string // Currently selected token for source chain
   targetCurrency: string // Currently selected token for target chain
   expireTime: string // Bitcoi HTLC expiration time
@@ -192,6 +199,7 @@ const initialState: OptionState = {
   txId: -1,
   ccTransactionId: '',
   ccTransactionStatus: 'idle',
+  ccTransactionRetrying: false,
   sourceCurrency: 'USDK',
   targetCurrency: 'USDK',
   compliantOption: true,
@@ -345,10 +353,21 @@ export const optionSlice = createSlice({
     setCCTransactionStatus: (
       state: OptionState,
       action: PayloadAction<
-        'initialized' | 'success' | 'failed' | 'idle' | 'error-id' | 'error-generic'
+        | 'initialized'
+        | 'success'
+        | 'failed'
+        | 'idle'
+        | 'error-id'
+        | 'error-generic'
       >
     ) => {
       state.ccTransactionStatus = action.payload
+    },
+    setCCTransactionRetrying: (
+      state: OptionState,
+      action: PayloadAction<boolean>
+    ) => {
+      state.ccTransactionRetrying = action.payload
     },
     setSourceCurrency: (state: OptionState, action: PayloadAction<string>) => {
       state.sourceCurrency = action.payload
@@ -442,6 +461,7 @@ export const {
   setTxId,
   setCCTransactionId,
   setCCTransactionStatus,
+  setCCTransactionRetrying,
   setSourceCurrency,
   setTargetCurrency,
   setCompliantOption,

--- a/src/store/selectors.tsx
+++ b/src/store/selectors.tsx
@@ -148,3 +148,5 @@ export const selectCCTransactionId = (state: RootState) =>
   state.option.ccTransactionId
 export const selectCCTransactionStatus = (state: RootState) =>
   state.option.ccTransactionStatus
+export const selectCCTransactionRetrying = (state: RootState) =>
+  state.option.ccTransactionRetrying


### PR DESCRIPTION
This feature only impacts on ramp transactions!

- Add retry logic
- Add extra ui notice for cc generic error widget

**To try, just hard code any incorrect value in the submit function of backend.**