### PR TITLE
fix: no target network selected in payment mode

### DIFF
--- a/src/components/KimaTransactionWidget.tsx
+++ b/src/components/KimaTransactionWidget.tsx
@@ -10,11 +10,7 @@ import {
 
 import '../index.css'
 
-import {
-  ChainName,
-  LoadingErrorMessage,
-  LoadingErrorTitle
-} from '@utils/constants'
+import { LoadingErrorMessage, LoadingErrorTitle } from '@utils/constants'
 import KimaWidgetWrapper from './KimaWidgetWrapper'
 import { useGetEnvOptions } from '../hooks/useGetEnvOptions'
 import { useKimaContext } from 'src/KimaProvider'
@@ -35,8 +31,6 @@ interface Props {
   helpURL?: string
   transactionOption?: TransactionOption
   paymentTitleOption?: PaymentTitleOption
-  excludedSourceNetworks?: Array<ChainName>
-  excludedTargetNetworks?: Array<ChainName>
 }
 
 const KimaTransactionWidget = ({
@@ -48,9 +42,7 @@ const KimaTransactionWidget = ({
   paymentTitleOption,
   helpURL = '',
   compliantOption = false,
-  transactionOption,
-  excludedSourceNetworks = [],
-  excludedTargetNetworks = []
+  transactionOption
 }: Props) => {
   const dispatch = useDispatch()
   const { kimaBackendUrl } = useKimaContext()
@@ -123,8 +115,6 @@ const KimaTransactionWidget = ({
         helpURL,
         compliantOption,
         transactionOption,
-        excludedSourceNetworks,
-        excludedTargetNetworks,
         chainData,
         envOptions
       }}

--- a/src/components/KimaWidgetWrapper.tsx
+++ b/src/components/KimaWidgetWrapper.tsx
@@ -40,13 +40,12 @@ import {
 import { TransactionWidget } from './TransactionWidget'
 import { TransferWidget } from './TransferWidget'
 import { useAppKitTheme } from '@reown/appkit/react'
-import { ChainName } from '@utils/constants'
 import { indexPluginsByChain } from '../pluginRegistry'
 import { useKimaContext } from 'src/KimaProvider'
 import { EnvOptions } from '../hooks/useGetEnvOptions'
 import { ChainData } from '@plugins/pluginTypes'
 import { useDebugCode } from '../hooks/useDebugMode'
-import log from 'loglevel'
+import log from '@utils/logger'
 import ErrorWidget from './ErrorWidget'
 
 interface Props {
@@ -59,8 +58,6 @@ interface Props {
   helpURL?: string
   transactionOption?: TransactionOption
   paymentTitleOption?: PaymentTitleOption
-  excludedSourceNetworks?: Array<ChainName>
-  excludedTargetNetworks?: Array<ChainName>
   chainData: ChainData[]
   envOptions: EnvOptions
 }
@@ -75,8 +72,6 @@ const KimaWidgetWrapper = ({
   helpURL = '',
   compliantOption = true,
   transactionOption,
-  excludedSourceNetworks = [],
-  excludedTargetNetworks = [],
   chainData,
   envOptions
 }: Props) => {

--- a/src/components/TransferWidget.tsx
+++ b/src/components/TransferWidget.tsx
@@ -203,7 +203,13 @@ export const TransferWidget = ({
     if (fees) {
       dispatch(setServiceFee(fees))
     }
-  }, [fees, dispatch])
+    if (transactionOption?.sourceChain) {
+      setInitialSelection((prev) => ({ ...prev, sourceSelection: false }))
+    }
+    if (mode === ModeOptions.payment || transactionOption?.targetChain) {
+      setInitialSelection((prev) => ({ ...prev, targetSelection: false }))
+    }
+  }, [fees, mode, transactionOption, dispatch])
 
   const { submitTransaction, isSubmitting } = useSubmitTransaction()
 

--- a/src/components/primary/NetworkSelector.tsx
+++ b/src/components/primary/NetworkSelector.tsx
@@ -11,13 +11,11 @@ import {
   setSourceChain,
   setSourceCurrency,
   setTargetChain,
-  setTargetAddress,
-  setTargetCurrency
+  setTargetAddress
 } from '@store/optionSlice'
 import Arrow from '@assets/icons/Arrow'
 import ChainIcon from '../reusable/ChainIcon'
 import {
-  ChainName,
   isEVMChain,
   lightDemoAccounts,
   lightDemoNetworks
@@ -66,22 +64,22 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({
   const isOriginSelector = type === 'origin'
 
   const networks = useMemo(() => {
-  return networkOptions.filter((network: ChainData) => {
-    const isSameAsSource = isOriginSelector
-      ? false
-      : network.shortName === sourceNetwork.shortName;
+    return networkOptions.filter((network: ChainData) => {
+      const isSameAsSource = isOriginSelector
+        ? false
+        : network.shortName === sourceNetwork.shortName
 
-    const isAllowedInLightMode =
-      mode !== ModeOptions.light || lightDemoNetworks.includes(network.shortName);
+      const isAllowedInLightMode =
+        mode !== ModeOptions.light ||
+        lightDemoNetworks.includes(network.shortName)
 
-    return (
-      network.supportedLocations.includes(type) &&
-      !isSameAsSource &&
-      isAllowedInLightMode
-    );
-  });
-}, [networkOptions, sourceNetwork, type, mode]);
-
+      return (
+        network.supportedLocations.includes(type) &&
+        !isSameAsSource &&
+        isAllowedInLightMode
+      )
+    })
+  }, [networkOptions, sourceNetwork, type, mode])
 
   const selectedNetwork = useMemo(() => {
     if (initialSelection) {
@@ -149,7 +147,7 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({
       }
     }
 
-    type === 'origin'
+    type === 'origin' && mode !== ModeOptions.payment
       ? setInitialSelection((prev) => ({ ...prev, sourceSelection: false }))
       : setInitialSelection((prev) => ({ ...prev, targetSelection: false }))
     setCollapsed(true) // Explicitly collapse the dropdown after selection
@@ -169,7 +167,7 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({
   }, [])
 
   useEffect(() => {
-    if(mode !== ModeOptions.light) return
+    if (mode !== ModeOptions.light) return
 
     if (isEVMChain(targetNetwork.shortName)) {
       dispatch(setTargetAddress(lightDemoAccounts.EVM))


### PR DESCRIPTION
* Fixes a bug in `payment` mode where the target network is not initially selected. This prevents the going to the next step.
* Removes the `exlcude***Network` widget props as this functionality was moved to the backend so these do nothing

![image](https://github.com/user-attachments/assets/1d578d30-e90c-40de-a49e-57ab643452e3)

This is related to the "initial selection" logic which does not take Payment mode or the default settings in `transactionObject` into account. @kima-bastian or @jeancarrie-kima , however added this code, please revisit these changes to fix those issues. I'm not sure the changes I've made are sufficient or if they break something else.